### PR TITLE
Bundle modes

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -17,6 +17,7 @@ function main(): void {
   var view = new CodeMirrorWidget(model);
 
   view.attach(document.getElementById('main'));
+  model.filename = 'test.js'
   view.update();
 
   window.onresize = () => view.update();

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -9,6 +9,7 @@
   },
   "files": [
     "../typings/codemirror/codemirror.d.ts",
+    "../typings/requirejs/requirejs.d.ts",
     "index.ts"
   ]
 }

--- a/example/webpack.conf.js
+++ b/example/webpack.conf.js
@@ -2,7 +2,8 @@
 module.exports = {
   entry: './example/index.ts',
   output: {
-    filename: './example/bundle.js'
+    path: './example',
+    filename: 'bundle.js'
   },
   resolve: {
     extensions: ['', '.ts', '.js']

--- a/lib/EditorWidget.d.ts
+++ b/lib/EditorWidget.d.ts
@@ -67,7 +67,7 @@ export declare class CodeMirrorWidget extends Widget {
      */
     protected onModelStateChanged(sender: IEditorViewModel, args: IChangedArgs<any>): void;
     /**
-     * Load a CodeMirror mode.
+     * Load and set a CodeMirror mode.
      */
     private _loadCodeMirrorMode(mode);
     private _editor;

--- a/lib/EditorWidget.d.ts
+++ b/lib/EditorWidget.d.ts
@@ -67,7 +67,7 @@ export declare class CodeMirrorWidget extends Widget {
      */
     protected onModelStateChanged(sender: IEditorViewModel, args: IChangedArgs<any>): void;
     /**
-     * Load a CodeMirror mode asynchronously.
+     * Load a CodeMirror mode.
      */
     private _loadCodeMirrorMode(mode);
     private _editor;

--- a/lib/EditorWidget.js
+++ b/lib/EditorWidget.js
@@ -200,15 +200,15 @@ var CodeMirrorWidget = (function (_super) {
         }
     };
     /**
-     * Load a CodeMirror mode.
+     * Load and set a CodeMirror mode.
      */
     CodeMirrorWidget.prototype._loadCodeMirrorMode = function (mode) {
         var _this = this;
-        // load codemirror mode module, and set the mode
         if (CodeMirror.modes.hasOwnProperty(mode)) {
             this._editor.setOption('mode', mode);
         }
         else {
+            // Bundle common modes.
             switch (mode) {
                 case 'python':
                     require('codemirror/mode/python/python');
@@ -236,8 +236,8 @@ var CodeMirrorWidget = (function (_super) {
                     this._editor.setOption('mode', mode);
                     break;
                 default:
-                    require.ensure([], function (require) {
-                        require("codemirror/mode/" + mode + "/" + mode + ".js");
+                    // Load the remaining mode bundle asynchronously.
+                    require([("codemirror/mode/" + mode + "/" + mode + ".js")], function () {
                         _this._editor.setOption('mode', mode);
                     });
                     break;

--- a/lib/EditorWidget.js
+++ b/lib/EditorWidget.js
@@ -200,16 +200,48 @@ var CodeMirrorWidget = (function (_super) {
         }
     };
     /**
-     * Load a CodeMirror mode asynchronously.
+     * Load a CodeMirror mode.
      */
     CodeMirrorWidget.prototype._loadCodeMirrorMode = function (mode) {
+        var _this = this;
         // load codemirror mode module, and set the mode
         if (CodeMirror.modes.hasOwnProperty(mode)) {
             this._editor.setOption('mode', mode);
         }
         else {
-            require("codemirror/mode/" + mode + "/" + mode + ".js");
-            this._editor.setOption('mode', mode);
+            switch (mode) {
+                case 'python':
+                    require('codemirror/mode/python/python');
+                    this._editor.setOption('mode', mode);
+                    break;
+                case 'javascript':
+                case 'typescript':
+                    require('codemirror/mode/javascript/javascript');
+                    this._editor.setOption('mode', mode);
+                    break;
+                case 'css':
+                    require('codemirror/mode/css/css');
+                    this._editor.setOption('mode', mode);
+                    break;
+                case 'julia':
+                    require('codemirror/mode/julia/julia');
+                    this._editor.setOption('mode', mode);
+                    break;
+                case 'r':
+                    require('codemirror/mode/r/r');
+                    this._editor.setOption('mode', mode);
+                    break;
+                case 'markdown':
+                    require('codemirror/mode/markdown/markdown');
+                    this._editor.setOption('mode', mode);
+                    break;
+                default:
+                    require.ensure([], function (require) {
+                        require("codemirror/mode/" + mode + "/" + mode + ".js");
+                        _this._editor.setOption('mode', mode);
+                    });
+                    break;
+            }
         }
     };
     return CodeMirrorWidget;

--- a/lib/EditorWidget.js
+++ b/lib/EditorWidget.js
@@ -80,16 +80,13 @@ var CodeMirrorWidget = (function (_super) {
      * Valid mimetypes are listed in https://github.com/codemirror/CodeMirror/blob/master/mode/meta.js.
      */
     CodeMirrorWidget.prototype.updateMimetype = function (mimetype) {
-        var _this = this;
         if (CodeMirror.mimeModes.hasOwnProperty(mimetype)) {
             this._editor.setOption('mode', mimetype);
         }
         else {
             var info = CodeMirror.findModeByMIME(mimetype);
             if (info) {
-                this._loadCodeMirrorMode(info.mode).then(function () {
-                    _this._editor.setOption('mode', mimetype);
-                });
+                this._loadCodeMirrorMode(info.mode);
             }
         }
     };
@@ -97,15 +94,12 @@ var CodeMirrorWidget = (function (_super) {
      * Set the mode by the given filename if the mimetype is not set.
      */
     CodeMirrorWidget.prototype.updateFilename = function (filename) {
-        var _this = this;
         if (this._model.mimetype) {
             return;
         }
         var info = CodeMirror.findModeByFileName(filename);
         if (info) {
-            this._loadCodeMirrorMode(info.mode).then(function () {
-                _this._editor.setOption('mode', info.mode);
-            });
+            this._loadCodeMirrorMode(info.mode);
         }
     };
     /**
@@ -209,12 +203,13 @@ var CodeMirrorWidget = (function (_super) {
      * Load a CodeMirror mode asynchronously.
      */
     CodeMirrorWidget.prototype._loadCodeMirrorMode = function (mode) {
-        // load codemirror mode module, returning a promise.
+        // load codemirror mode module, and set the mode
         if (CodeMirror.modes.hasOwnProperty(mode)) {
-            return Promise.resolve();
+            this._editor.setOption('mode', mode);
         }
         else {
-            return System.import("codemirror/mode/" + mode + "/" + mode);
+            require("codemirror/mode/" + mode + "/" + mode + ".js");
+            this._editor.setOption('mode', mode);
         }
     };
     return CodeMirrorWidget;

--- a/scripts/tdoptions.json
+++ b/scripts/tdoptions.json
@@ -8,7 +8,7 @@
   "src": [
     "src/index.ts",
     "typings/codemirror/codemirror.d.ts",
-    "typings/systemjs/systemjs.d.ts",
+    "typings/requirejs/requirejs.d.ts",
     "typings/diff-match-patch/diff-match-patch.d.ts",
     "typings/es6-promise.d.ts"
   ]

--- a/src/EditorWidget.ts
+++ b/src/EditorWidget.ts
@@ -250,8 +250,52 @@ class CodeMirrorWidget extends Widget {
     if (CodeMirror.modes.hasOwnProperty(mode)) {
       this._editor.setOption('mode', mode);
     } else {
-      require(`codemirror/mode/${mode}/${mode}.js`);
-      this._editor.setOption('mode', mode);
+      switch(mode) {
+      case 'python':
+        require.ensure(['codemirror/mode/python/python'], require => {
+          require('codemirror/mode/python/python');
+          this._editor.setOption('mode', mode);
+        });
+        break;
+      case 'javascript':
+      case 'typescript':
+        require.ensure(['codemirror/mode/javascript/javascript'], require => {
+          require('codemirror/mode/javascript/javascript');
+          this._editor.setOption('mode', mode);
+        });
+        break;
+      case 'css':
+        require.ensure(['codemirror/mode/css/css'], require => {
+          require('codemirror/mode/css/css');
+          this._editor.setOption('mode', mode);
+        });
+        break;
+      case 'julia':
+        require.ensure(['codemirror/mode/julia/julia'], require => {
+          require('codemirror/mode/julia/julia');
+          this._editor.setOption('mode', mode);
+        });
+        break;
+      case 'r':
+        require.ensure(['codemirror/mode/r/r'], require => {
+          require('codemirror/mode/r/r');
+          this._editor.setOption('mode', mode);
+        });
+        break;
+      case 'markdown':
+        require.ensure(['codemirror/mode/markdown/markdown'], require => {
+          require('codemirror/mode/markdown/');
+          this._editor.setOption('mode', mode);
+        });
+        break;
+      default:
+        require.ensure([], require => {
+          require(`codemirror/mode/${mode}/${mode}.js`);
+          this._editor.setOption('mode', mode);
+        });
+        break;
+      }
+
     }
   }
 

--- a/src/EditorWidget.ts
+++ b/src/EditorWidget.ts
@@ -33,13 +33,6 @@ import {
 } from './EditorViewModel';
 
 
-declare var require: {
-  <T>(path: string): T;
-  (paths: string[], callback: (...modules: any[]) => void): void;
-  ensure: (paths: string[], callback: (require: <T>(path: string) => T) => void) => void;
-};
-
-
 /**
  * The class name added to CodeMirrorWidget instances.
  */
@@ -243,59 +236,47 @@ class CodeMirrorWidget extends Widget {
   }
 
   /**
-   * Load a CodeMirror mode asynchronously.
+   * Load and set a CodeMirror mode.
    */
   private _loadCodeMirrorMode(mode: string): void {
-    // load codemirror mode module, and set the mode
     if (CodeMirror.modes.hasOwnProperty(mode)) {
       this._editor.setOption('mode', mode);
     } else {
+      // Bundle common modes.
       switch(mode) {
       case 'python':
-        require.ensure(['codemirror/mode/python/python'], require => {
-          require('codemirror/mode/python/python');
-          this._editor.setOption('mode', mode);
-        });
+        require('codemirror/mode/python/python');
+        this._editor.setOption('mode', mode);
         break;
       case 'javascript':
       case 'typescript':
-        require.ensure(['codemirror/mode/javascript/javascript'], require => {
-          require('codemirror/mode/javascript/javascript');
-          this._editor.setOption('mode', mode);
-        });
+        require('codemirror/mode/javascript/javascript');
+        this._editor.setOption('mode', mode);
         break;
       case 'css':
-        require.ensure(['codemirror/mode/css/css'], require => {
-          require('codemirror/mode/css/css');
-          this._editor.setOption('mode', mode);
-        });
+        require('codemirror/mode/css/css');
+        this._editor.setOption('mode', mode);
         break;
       case 'julia':
-        require.ensure(['codemirror/mode/julia/julia'], require => {
-          require('codemirror/mode/julia/julia');
-          this._editor.setOption('mode', mode);
-        });
+        require('codemirror/mode/julia/julia');
+        this._editor.setOption('mode', mode);
         break;
       case 'r':
-        require.ensure(['codemirror/mode/r/r'], require => {
-          require('codemirror/mode/r/r');
-          this._editor.setOption('mode', mode);
-        });
+        require('codemirror/mode/r/r');
+        this._editor.setOption('mode', mode);
         break;
       case 'markdown':
-        require.ensure(['codemirror/mode/markdown/markdown'], require => {
-          require('codemirror/mode/markdown/');
-          this._editor.setOption('mode', mode);
-        });
+        require('codemirror/mode/markdown/markdown');
+        this._editor.setOption('mode', mode);
         break;
       default:
+        // Load the remaining mode bundle asynchronously.
         require.ensure([], require => {
           require(`codemirror/mode/${mode}/${mode}.js`);
           this._editor.setOption('mode', mode);
         });
         break;
       }
-
     }
   }
 

--- a/src/EditorWidget.ts
+++ b/src/EditorWidget.ts
@@ -33,6 +33,13 @@ import {
 } from './EditorViewModel';
 
 
+declare var require: {
+  <T>(path: string): T;
+  (paths: string[], callback: (...modules: any[]) => void): void;
+  ensure: (paths: string[], callback: (require: <T>(path: string) => T) => void) => void;
+};
+
+
 /**
  * The class name added to CodeMirrorWidget instances.
  */
@@ -114,9 +121,7 @@ class CodeMirrorWidget extends Widget {
     } else {
       let info = CodeMirror.findModeByMIME(mimetype);
       if (info) {
-        this._loadCodeMirrorMode(info.mode).then(() => {
-          this._editor.setOption('mode', mimetype);
-        })
+        this._loadCodeMirrorMode(info.mode);
       }
     }
   }
@@ -130,9 +135,7 @@ class CodeMirrorWidget extends Widget {
     }
     let info = CodeMirror.findModeByFileName(filename);
     if (info) {
-      this._loadCodeMirrorMode(info.mode).then(() => {
-        this._editor.setOption('mode', info.mode);
-      });
+      this._loadCodeMirrorMode(info.mode);
     }
   }
 
@@ -242,12 +245,13 @@ class CodeMirrorWidget extends Widget {
   /**
    * Load a CodeMirror mode asynchronously.
    */
-  private _loadCodeMirrorMode(mode: string): Promise<any> {
-    // load codemirror mode module, returning a promise.
+  private _loadCodeMirrorMode(mode: string): void {
+    // load codemirror mode module, and set the mode
     if (CodeMirror.modes.hasOwnProperty(mode)) {
-      return Promise.resolve();
+      this._editor.setOption('mode', mode);
     } else {
-      return System.import(`codemirror/mode/${mode}/${mode}`);
+      require(`codemirror/mode/${mode}/${mode}.js`);
+      this._editor.setOption('mode', mode);
     }
   }
 

--- a/src/EditorWidget.ts
+++ b/src/EditorWidget.ts
@@ -271,8 +271,7 @@ class CodeMirrorWidget extends Widget {
         break;
       default:
         // Load the remaining mode bundle asynchronously.
-        require.ensure([], require => {
-          require(`codemirror/mode/${mode}/${mode}.js`);
+        require([`codemirror/mode/${mode}/${mode}.js`], () => {
           this._editor.setOption('mode', mode);
         });
         break;

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -11,7 +11,7 @@
   "files": [
     "../typings/es6-promise.d.ts",
     "../typings/codemirror/codemirror.d.ts",
-    "../typings/systemjs/systemjs.d.ts",
+    "../typings/requirejs/requirejs.d.ts",
     "../typings/diff-match-patch/diff-match-patch.d.ts",
     "index.ts"
   ]

--- a/typings/requirejs/requirejs.d.ts
+++ b/typings/requirejs/requirejs.d.ts
@@ -1,0 +1,397 @@
+// Type definitions for RequireJS 2.1.20
+// Project: http://requirejs.org/
+// Definitions by: Josh Baldwin <https://github.com/jbaldwin/>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
+
+/*
+require-2.1.8.d.ts may be freely distributed under the MIT license.
+
+Copyright (c) 2013 Josh Baldwin https://github.com/jbaldwin/require.d.ts
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+declare module 'module' {
+    var mod: {
+        config: () => any;
+        id: string;
+        uri: string;
+    }
+    export = mod;
+}
+
+interface RequireError extends Error {
+
+    /**
+    * The error ID that maps to an ID on a web page.
+    **/
+    requireType: string;
+
+    /**
+    * Required modules.
+    **/
+    requireModules: string[];
+
+    /**
+    * The original error, if there is one (might be null).
+    **/
+    originalError: Error;
+}
+
+interface RequireShim {
+
+    /**
+    * List of dependencies.
+    **/
+    deps?: string[];
+
+    /**
+    * Name the module will be exported as.
+    **/
+    exports?: string;
+
+    /**
+    * Initialize function with all dependcies passed in,
+    * if the function returns a value then that value is used
+    * as the module export value instead of the object
+    * found via the 'exports' string.
+    * @param dependencies
+    * @return
+    **/
+    init?: (...dependencies: any[]) => any;
+}
+
+interface RequireConfig {
+
+    // The root path to use for all module lookups.
+    baseUrl?: string;
+
+    // Path mappings for module names not found directly under
+    // baseUrl.
+    paths?: { [key: string]: any; };
+
+
+    // Dictionary of Shim's.
+    // does not cover case of key->string[]
+    shim?: { [key: string]: RequireShim; };
+
+    /**
+    * For the given module prefix, instead of loading the
+    * module with the given ID, substitude a different
+    * module ID.
+    *
+    * @example
+    * requirejs.config({
+    *    map: {
+    *        'some/newmodule': {
+    *            'foo': 'foo1.2'
+    *        },
+    *        'some/oldmodule': {
+    *            'foo': 'foo1.0'
+    *        }
+    *    }
+    * });
+    **/
+    map?: {
+        [id: string]: {
+            [id: string]: string;
+        };
+    };
+
+    /**
+    * Allows pointing multiple module IDs to a module ID that contains a bundle of modules.
+    *
+    * @example
+    * requirejs.config({
+    *    bundles: {
+    *        'primary': ['main', 'util', 'text', 'text!template.html'],
+    *        'secondary': ['text!secondary.html']
+    *    }
+    * });
+    **/
+    bundles?: { [key: string]: string[]; };
+
+    /**
+    * AMD configurations, use module.config() to access in
+    * define() functions
+    **/
+    config?: { [id: string]: {}; };
+
+    /**
+    * Configures loading modules from CommonJS packages.
+    **/
+    packages?: {};
+
+    /**
+    * The number of seconds to wait before giving up on loading
+    * a script.  The default is 7 seconds.
+    **/
+    waitSeconds?: number;
+
+    /**
+    * A name to give to a loading context.  This allows require.js
+    * to load multiple versions of modules in a page, as long as
+    * each top-level require call specifies a unique context string.
+    **/
+    context?: string;
+
+    /**
+    * An array of dependencies to load.
+    **/
+    deps?: string[];
+
+    /**
+    * A function to pass to require that should be require after
+    * deps have been loaded.
+    * @param modules
+    **/
+    callback?: (...modules: any[]) => void;
+
+    /**
+    * If set to true, an error will be thrown if a script loads
+    * that does not call define() or have shim exports string
+    * value that can be checked.
+    **/
+    enforceDefine?: boolean;
+
+    /**
+    * If set to true, document.createElementNS() will be used
+    * to create script elements.
+    **/
+    xhtml?: boolean;
+
+    /**
+    * Extra query string arguments appended to URLs that RequireJS
+    * uses to fetch resources.  Most useful to cache bust when
+    * the browser or server is not configured correctly.
+    *
+    * @example
+    * urlArgs: "bust= + (new Date()).getTime()
+    **/
+    urlArgs?: string;
+
+    /**
+    * Specify the value for the type="" attribute used for script
+    * tags inserted into the document by RequireJS.  Default is
+    * "text/javascript".  To use Firefox's JavasScript 1.8
+    * features, use "text/javascript;version=1.8".
+    **/
+    scriptType?: string;
+
+    /**
+    * If set to true, skips the data-main attribute scanning done
+    * to start module loading. Useful if RequireJS is embedded in
+    * a utility library that may interact with other RequireJS
+    * library on the page, and the embedded version should not do
+    * data-main loading.
+    **/
+    skipDataMain?: boolean;
+
+    /**
+    * Allow extending requirejs to support Subresource Integrity
+    * (SRI).
+    **/
+    onNodeCreated?: (node: HTMLScriptElement, config: RequireConfig, moduleName: string, url: string) => void;
+}
+
+// todo: not sure what to do with this guy
+interface RequireModule {
+
+    /**
+    *
+    **/
+    config(): {};
+
+}
+
+/**
+*
+**/
+interface RequireMap {
+
+    /**
+    *
+    **/
+    prefix: string;
+
+    /**
+    *
+    **/
+    name: string;
+
+    /**
+    *
+    **/
+    parentMap: RequireMap;
+
+    /**
+    *
+    **/
+    url: string;
+
+    /**
+    *
+    **/
+    originalName: string;
+
+    /**
+    *
+    **/
+    fullName: string;
+}
+
+interface Require {
+
+    /**
+    * Configure require.js
+    **/
+    config(config: RequireConfig): Require;
+
+    /**
+    * CommonJS require call
+    * @param module Module to load
+    * @return The loaded module
+    */
+    (module: string): any;
+
+    /**
+    * Start the main app logic.
+    * Callback is optional.
+    * Can alternatively use deps and callback.
+    * @param modules Required modules to load.
+    **/
+    (modules: string[]): void;
+
+    /**
+    * @see Require()
+    * @param ready Called when required modules are ready.
+    **/
+    (modules: string[], ready: Function): void;
+
+    /**
+    * @see http://requirejs.org/docs/api.html#errbacks
+    * @param ready Called when required modules are ready.
+    **/
+    (modules: string[], ready: Function, errback: Function): void;
+
+    /**
+    * Generate URLs from require module
+    * @param module Module to URL
+    * @return URL string
+    **/
+    toUrl(module: string): string;
+
+    /**
+    * Returns true if the module has already been loaded and defined.
+    * @param module Module to check
+    **/
+    defined(module: string): boolean;
+
+    /**
+    * Returns true if the module has already been requested or is in the process of loading and should be available at some point.
+    * @param module Module to check
+    **/
+    specified(module: string): boolean;
+
+    /**
+    * On Error override
+    * @param err
+    **/
+    onError(err: RequireError, errback?: (err: RequireError) => void): void;
+
+    /**
+    * Undefine a module
+    * @param module Module to undefine.
+    **/
+    undef(module: string): void;
+
+    /**
+    * Semi-private function, overload in special instance of undef()
+    **/
+    onResourceLoad(context: Object, map: RequireMap, depArray: RequireMap[]): void;
+}
+
+interface RequireDefine {
+
+    /**
+    * Define Simple Name/Value Pairs
+    * @param config Dictionary of Named/Value pairs for the config.
+    **/
+    (config: { [key: string]: any; }): void;
+
+    /**
+    * Define function.
+    * @param func: The function module.
+    **/
+    (func: () => any): void;
+
+    /**
+    * Define function with dependencies.
+    * @param deps List of dependencies module IDs.
+    * @param ready Callback function when the dependencies are loaded.
+    *    callback param deps module dependencies
+    *    callback return module definition
+    **/
+        (deps: string[], ready: Function): void;
+
+    /**
+    *  Define module with simplified CommonJS wrapper.
+    * @param ready
+    *    callback require requirejs instance
+    *    callback exports exports object
+    *    callback module module
+    *    callback return module definition
+    **/
+    (ready: (require: Require, exports: { [key: string]: any; }, module: RequireModule) => any): void;
+
+    /**
+    * Define a module with a name and dependencies.
+    * @param name The name of the module.
+    * @param deps List of dependencies module IDs.
+    * @param ready Callback function when the dependencies are loaded.
+    *    callback deps module dependencies
+    *    callback return module definition
+    **/
+    (name: string, deps: string[], ready: Function): void;
+
+    /**
+    * Define a module with a name.
+    * @param name The name of the module.
+    * @param ready Callback function when the dependencies are loaded.
+    *    callback return module definition
+    **/
+    (name: string, ready: Function): void;
+
+    /**
+    * Used to allow a clear indicator that a global define function (as needed for script src browser loading) conforms
+    * to the AMD API, any global define function SHOULD have a property called "amd" whose value is an object.
+    * This helps avoid conflict with any other existing JavaScript code that could have defined a define() function
+    * that does not conform to the AMD API.
+    * define.amd.jQuery is specific to jQuery and indicates that the loader is able to account for multiple version
+    * of jQuery being loaded simultaneously.
+    */
+    amd: Object;
+}
+
+// Ambient declarations for 'require' and 'define'
+declare var requirejs: Require;
+declare var require: Require;
+declare var define: RequireDefine;


### PR DESCRIPTION
Bundle common modes and bundle the rest separately, using an AMD style import.

This change allows for consumption by both Webpack and SystemJS.

cc @jasongrout
